### PR TITLE
Fixed Dormammu synergy with Hood. Added Blackbolt synergy with Karnak

### DIFF
--- a/src/data/synergies.js
+++ b/src/data/synergies.js
@@ -59,6 +59,7 @@ const synergies = [
         ...fromStars(2, 4, [ CHAMPION.SPIDERMAN, CHAMPION.CYCLOPS ], EFFECT.ARMOR),
         ...fromStars(3, 4, [ CHAMPION.KANG ], EFFECT.ATTACK),
         ...fromStars(3, 4, [ CHAMPION.HULK ], EFFECT.CRITICAL_DAMAGE),
+        ...fromStars(3, 5, [ CHAMPION.KARNAK ], EFFECT.HEALTH),
     ]),
 
     ...fromId(CHAMPION.CAPTAINMARVEL, [
@@ -603,7 +604,7 @@ const synergies = [
     ]),
 
     ...fromId(CHAMPION.DORMAMMU, [
-        ...fromStars(3, 5, [ CHAMPION.GUILLOTINE ], EFFECT.INSEPARABLE),
+        ...fromStars(3, 5, [ CHAMPION.HOOD ], EFFECT.INSEPARABLE),
         ...fromStars(3, 5, [ CHAMPION.DRSTRANGE ], EFFECT.ATTACK),
         ...fromStars(4, 5, [ CHAMPION.DRVOODOO ], EFFECT.CRITICAL_RATE),
     ]),


### PR DESCRIPTION
Switched Dormammu's Inseparable synergy from Guillotine to Hood.
Added Karnak as a Health synergy for Blackbolt. Medusa should be added as well but she is not in the app yet.